### PR TITLE
Removed hardcoded text on welcome e-mail messages

### DIFF
--- a/app/views/email_notifications/welcome_attendance.en.html.haml
+++ b/app/views/email_notifications/welcome_attendance.en.html.haml
@@ -7,7 +7,7 @@ Hi #{h(@attendance.full_name)},
 %ul
   %li Bring a valid document
   %li If you are registered as student, you’ll be invited to comprove it by show your student id. You'll be asked to pay the full price if you don't have it.
-  %li The welcome coffee and the registration will be in place at #{@attendance.event.start_date.to_date.strftime('%d/%m/%Y')}
+  %li The welcome coffee and the registration will be in place at #{@attendance.event.start_date.to_date.strftime('%H:%M')}
   %li Check #{@attendance.event.link} for address and how to get there details.
 
 %p If you have any questions, please contact us at #{mail_to @attendance.event.main_email_contact}

--- a/app/views/email_notifications/welcome_attendance.en.html.haml
+++ b/app/views/email_notifications/welcome_attendance.en.html.haml
@@ -7,7 +7,7 @@ Hi #{h(@attendance.full_name)},
 %ul
   %li Bring a valid document
   %li If you are registered as student, you’ll be invited to comprove it by show your student id. You'll be asked to pay the full price if you don't have it.
-  %li The welcome coffee and the registration will be in place at 9:00
+  %li The welcome coffee and the registration will be in place at #{@attendance.event.start_date.to_date.strftime('%d/%m/%Y')}
   %li Check #{@attendance.event.link} for address and how to get there details.
 
 %p If you have any questions, please contact us at #{mail_to @attendance.event.main_email_contact}

--- a/app/views/email_notifications/welcome_attendance.en.text.haml
+++ b/app/views/email_notifications/welcome_attendance.en.text.haml
@@ -7,7 +7,7 @@ You should remember to:
 
 * Bring a valid document
 * If you are registered as student, you’ll be invited to comprove it showing your student id. You'll be asked to pay the full price if you don't have it.
-* The welcome coffee and the registration will be in place at #{@attendance.event.start_date.to_date.strftime('%d/%m/%Y')}
+* The welcome coffee and the registration will be in place at #{@attendance.event.start_date.to_date.strftime('%H:%M')}
 * Check #{@attendance.event.link} for address and how to get there details.
 
 If you have any questions, please contact us at #{mail_to @attendance.event.main_email_contact}

--- a/app/views/email_notifications/welcome_attendance.en.text.haml
+++ b/app/views/email_notifications/welcome_attendance.en.text.haml
@@ -7,7 +7,7 @@ You should remember to:
 
 * Bring a valid document
 * If you are registered as student, you’ll be invited to comprove it showing your student id. You'll be asked to pay the full price if you don't have it.
-* The welcome coffee and the registration will be in place at 9:00
+* The welcome coffee and the registration will be in place at #{@attendance.event.start_date.to_date.strftime('%d/%m/%Y')}
 * Check #{@attendance.event.link} for address and how to get there details.
 
 If you have any questions, please contact us at #{mail_to @attendance.event.main_email_contact}

--- a/app/views/email_notifications/welcome_attendance.pt.html.haml
+++ b/app/views/email_notifications/welcome_attendance.pt.html.haml
@@ -1,13 +1,13 @@
 Oi #{h(@attendance.full_name)},
 
-%p Amanhã é o grande dia! Mais um passo em direção de uma Floripa mais ágil. =)
+%p Amanhã será mais um dia ágil =)
 
 %p É indispensável que você se lembre de:
 
 %ul
   %li Trazer um documento válido com foto para o credenciamento.
   %li Se você se cadastrou como estudante, não esqueça o comprovante. Se você esquecer, precisará pagar a diferença da entrada total.
-  %li O credenciamento e o coffee de boas vindas começarão às 9:00.
+  %li O credenciamento e o coffee de boas vindas começarão às #{@attendance.event.start_date.to_date.strftime('%H:%M')}.
   %li Consulte #{@attendance.event.link} para informações detalhadas de como chegar.
 
 %p Qualquer dúvida, entre em contato através do email #{@attendance.event.main_email_contact}.

--- a/app/views/email_notifications/welcome_attendance.pt.text.haml
+++ b/app/views/email_notifications/welcome_attendance.pt.text.haml
@@ -1,12 +1,12 @@
 Oi #{h(@attendance.full_name)},
 
-Amanhã é o grande dia. Mais um passo em direção de uma Floripa mais ágil. =)
+Amanhã será mais um dia ágil =)
 
 É indispensável que você se lembre de:
 
 * Trazer um documento válido com foto para o credenciamento.
 * Se você se cadastrou como estudante, não esqueça o comprovante. Se você esquecer, precisará pagar a diferença da entrada total.
-* O credenciamento e o coffee de boas vindas começarão às 9:00.
+* O credenciamento e o coffee de boas vindas começarão às #{@attendance.event.start_date.to_date.strftime('%H:%M')}.
 * Consulte #{@attendance.event.link} para informações detalhadas de como chegar.
 
 Qualquer dúvida, entre em contato através do email #{@attendance.event.main_email_contact}

--- a/spec/mailers/email_notifications_spec.rb
+++ b/spec/mailers/email_notifications_spec.rb
@@ -255,8 +255,9 @@ describe EmailNotifications, type: :mailer do
         expect(mail.to).to eq [attendance.email]
         expect(mail.cc).to eq [APP_CONFIG[:organizer][:email]]
         expect(mail.encoded).to match(/Oi #{attendance.full_name},/)
-        expect(mail.encoded).to match(/o grande dia!/)
+        expect(mail.encoded).to match(/mais um dia/)
         expect(mail.encoded).to match(/#{attendance.event.main_email_contact}/)
+        expect(mail.encoded).to match(/#{attendance.event.start_date.to_date.strftime('%H:%M')}/)
         expect(mail.subject).to eq("Bem vindo ao #{event.name}! É amanhã!")
       end
     end


### PR DESCRIPTION
This issue was already resolved by another commit, so this PR only fixes the harcoded messages on welcome mail messages.

Closes #304 

